### PR TITLE
Use open ranges for documentation generator and unexpected-markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "jshint": "2.9.1",
     "mocha": "2.4.5",
     "unexpected": "10.10.0",
-    "unexpected-documentation-site-generator": "4.0.0",
-    "unexpected-markdown": "1.3.1"
+    "unexpected-documentation-site-generator": "^4.0.0",
+    "unexpected-markdown": "^1.3.4"
   },
   "dependencies": {
     "es6-set": "0.1.4"


### PR DESCRIPTION
Use open semver ranges for unexpected-documentation-site-generator and unexpected-markdown.