### PR TITLE
Alter the plugin to use stricter "to satisfy" semantics.

### DIFF
--- a/documentation/assertions/Set/to-have-items-satisfying.md
+++ b/documentation/assertions/Set/to-have-items-satisfying.md
@@ -15,7 +15,7 @@ Set([
 ```
 
 In order to check a property holds for all the items, an assertion can be
-passed as the argument - in this example we assert that all the items in
+passed as the argument – in this example we assert that all the items in
 the set are numbers:
 
 ```js

--- a/documentation/assertions/Set/to-have-items-satisfying.md
+++ b/documentation/assertions/Set/to-have-items-satisfying.md
@@ -15,7 +15,7 @@ Set([
 ```
 
 In order to check a property holds for all the items, an assertion can be
-passsed as the argument - in this example we assert that all the items in
+passed as the argument - in this example we assert that all the items in
 the set are numbers:
 
 ```js

--- a/documentation/assertions/Set/to-have-items-satisfying.md
+++ b/documentation/assertions/Set/to-have-items-satisfying.md
@@ -8,9 +8,9 @@ expect(new Set([1, 2, 3]), 'to have items satisfying', [1, { foo: 'bar' }, 3]);
 expected Set([ 1, 2, 3 ]) to have items satisfying [ 1, { foo: 'bar' }, 3 ]
 
 Set([
-  1,
-  2, // should equal { foo: 'bar' }
-  3
+  1, // should equal [ 1, { foo: 'bar' }, 3 ]
+  2, // should equal [ 1, { foo: 'bar' }, 3 ]
+  3 // should equal [ 1, { foo: 'bar' }, 3 ]
 ])
 ```
 
@@ -38,20 +38,18 @@ properties. In order to enforce that all properties are present, the `exhaustive
 flag can be used:
 
 ```js
-expect(
-  new Set([{ foo: true, bar: true }, { baz: false }]),
-  'to exhaustively satisfy',
-  new Set([{ foo: true }, { baz: false }])
-);
+expect(new Set([[{ foo: true, bar: true }], [1]]), 'to have items satisfying', [
+  expect.it('to be an object'),
+]);
 ```
 
 ```output
-expected Set([ { foo: true, bar: true }, { baz: false } ])
-to exhaustively satisfy Set([ { foo: true }, { baz: false } ])
+expected Set to have items satisfying [ expect.it('to be an object') ]
 
 Set([
-  { foo: true, bar: true }, // should be removed
-  { baz: false }
-  // missing { foo: true }
+  [ { foo: true, bar: true } ],
+  [
+    1 // should be an object
+  ]
 ])
 ```

--- a/documentation/assertions/Set/to-have-items-satisfying.md
+++ b/documentation/assertions/Set/to-have-items-satisfying.md
@@ -1,0 +1,57 @@
+Asserts the items contained by a Set satisfy a particular list of items.
+
+```js
+expect(new Set([1, 2, 3]), 'to have items satisfying', [1, { foo: 'bar' }, 3]);
+```
+
+```output
+expected Set([ 1, 2, 3 ]) to have items satisfying [ 1, { foo: 'bar' }, 3 ]
+
+Set([
+  1,
+  2, // should equal { foo: 'bar' }
+  3
+])
+```
+
+In order to check a property holds for all the items, an assertion can be
+passsed as the argument - in this example we assert that all the items in
+the set are numbers:
+
+```js
+expect(new Set([1, 2, []]), 'to have items satisfying', 'to be a number');
+```
+
+```output
+expected Set([ 1, 2, [] ]) to have items satisfying to be a number
+
+Set([
+  1,
+  2,
+  [] // should be a number
+])
+```
+
+The exact number of elements in a Set must always be matched. However, nested
+objects are, be default, compared using "satisfy" semantics which allow missing
+properties. In order to enforce that all properties are present, the `exhaustively`
+flag can be used:
+
+```js
+expect(
+  new Set([{ foo: true, bar: true }, { baz: false }]),
+  'to exhaustively satisfy',
+  new Set([{ foo: true }, { baz: false }])
+);
+```
+
+```output
+expected Set([ { foo: true, bar: true }, { baz: false } ])
+to exhaustively satisfy Set([ { foo: true }, { baz: false } ])
+
+Set([
+  { foo: true, bar: true }, // should be removed
+  { baz: false }
+  // missing { foo: true }
+])
+```

--- a/documentation/assertions/Set/to-satisfy.md
+++ b/documentation/assertions/Set/to-satisfy.md
@@ -2,11 +2,15 @@ Asserts that a Set instance has at least one element satisfying each given
 spec.
 
 ```js
-expect(new Set([1, 2, 3]), 'to satisfy', new Set([
-  1,
-  expect.it('to be less than or equal to', 1),
-  expect.it('to be greater than', 10),
-]));
+expect(
+  new Set([1, 2, 3]),
+  'to satisfy',
+  new Set([
+    1,
+    expect.it('to be less than or equal to', 1),
+    expect.it('to be greater than', 10),
+  ])
+);
 ```
 
 ```output

--- a/documentation/assertions/Set/to-satisfy.md
+++ b/documentation/assertions/Set/to-satisfy.md
@@ -2,25 +2,25 @@ Asserts that a Set instance has at least one element satisfying each given
 spec.
 
 ```js
-expect(new Set([1, 2, 3]), 'to satisfy', [
+expect(new Set([1, 2, 3]), 'to satisfy', new Set([
   1,
   expect.it('to be less than or equal to', 1),
   expect.it('to be greater than', 10),
-]);
+]));
 ```
 
 ```output
 expected Set([ 1, 2, 3 ]) to satisfy
-[
+Set([
   1,
   expect.it('to be less than or equal to', 1),
   expect.it('to be greater than', 10)
-]
+])
 
 Set([
   1,
-  2,
-  3
+  2, // should be removed
+  3 // should be removed
   // missing: should be greater than 10
 ])
 ```
@@ -29,11 +29,11 @@ If the subject should not contain additional elements, use the `exhaustively`
 flag:
 
 ```js
-expect(new Set([1, 2]), 'to exhaustively satisfy', [2]);
+expect(new Set([1, 2]), 'to exhaustively satisfy', new Set([2]));
 ```
 
 ```output
-expected Set([ 1, 2 ]) to exhaustively satisfy [ 2 ]
+expected Set([ 1, 2 ]) to exhaustively satisfy Set([ 2 ])
 
 Set([
   1, // should be removed

--- a/documentation/assertions/Set/to-satisfy.md
+++ b/documentation/assertions/Set/to-satisfy.md
@@ -35,7 +35,11 @@ properties. In order to enforce that all properties are present, the `exhaustive
 flag can be used:
 
 ```js
-expect(new Set([1, { foo: true, bar: false }]), 'to exhaustively satisfy', new Set([1, { foo: true }]));
+expect(
+  new Set([1, { foo: true, bar: false }]),
+  'to exhaustively satisfy',
+  new Set([1, { foo: true }])
+);
 ```
 
 ```output

--- a/documentation/assertions/Set/to-satisfy.md
+++ b/documentation/assertions/Set/to-satisfy.md
@@ -29,18 +29,22 @@ Set([
 ])
 ```
 
-If the subject should not contain additional elements, use the `exhaustively`
-flag:
+The exact number of elements in a Set must always be matched. However, nested
+objects are, be default, compared using "satisfy" semantics which allow missing
+properties. In order to enforce that all properties are present, the `exhaustively`
+flag can be used:
 
 ```js
-expect(new Set([1, 2]), 'to exhaustively satisfy', new Set([2]));
+expect(new Set([1, { foo: true, bar: false }]), 'to exhaustively satisfy', new Set([1, { foo: true }]));
 ```
 
 ```output
-expected Set([ 1, 2 ]) to exhaustively satisfy Set([ 2 ])
+expected Set([ 1, { foo: true, bar: false } ])
+to exhaustively satisfy Set([ 1, { foo: true } ])
 
 Set([
-  1, // should be removed
-  2
+  1,
+  { foo: true, bar: false } // should be removed
+  // missing { foo: true }
 ])
 ```

--- a/documentation/assertions/array-like/with-set-semantics.md
+++ b/documentation/assertions/array-like/with-set-semantics.md
@@ -6,19 +6,19 @@ accessible when you need to make assertions about an array without considering
 the order or duplicate items.
 
 ```js
-expect([3, 2, 1], 'with set semantics to satisfy', [1]);
+expect([3, 2, 1], 'with set semantics to satisfy', new Set([1, 2, 3]));
 ```
 
 ```js
-expect([3, 2, 1], 'with set semantics to exhaustively satisfy', [1]);
+expect([3, 2, 1], 'with set semantics to satisfy', new Set([1, 2]));
 ```
 
 ```output
-expected [ 3, 2, 1 ] with set semantics to exhaustively satisfy [ 1 ]
+expected [ 3, 2, 1 ] with set semantics to satisfy Set([ 1, 2 ])
 
 Set([
   3, // should be removed
-  2, // should be removed
+  2,
   1
 ])
 ```

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -13,11 +13,11 @@ Add support to [Unexpected](http://unexpected.js.org) for testing [Set](https://
 [![Dependency Status](https://david-dm.org/unexpectedjs/unexpected-set.svg)](https://david-dm.org/unexpectedjs/unexpected-set)
 
 ```js
-expect(new Set([1, 2, 3]), 'to satisfy', [3, 4]);
+expect(new Set([1, 2, 3]), 'to satisfy', new Set([1, 2, 3, 4]));
 ```
 
 ```output
-expected Set([ 1, 2, 3 ]) to satisfy [ 3, 4 ]
+expected Set([ 1, 2, 3 ]) to satisfy Set([ 1, 2, 3, 4 ])
 
 Set([
   1,

--- a/lib/unexpected-set.js
+++ b/lib/unexpected-set.js
@@ -228,14 +228,18 @@ module.exports = {
       }
     );
 
+    expect.addAssertion('<Set> [not] to be empty', (expect, subject) => {
+      expect(subject.size, '[not] to equal', 0);
+    });
+
     expect.addAssertion(
       [
-        '<Set> to have items [exhaustively] satisfying <any+>',
+        '<Set> to have items [exhaustively] satisfying <any>',
         '<Set> to have items [exhaustively] satisfying <assertion>',
       ],
       (expect, subject, nextArg) => {
         expect.errorMode = 'nested';
-        expect(subject.size, 'not to equal', 0);
+        expect(subject, 'not to be empty');
         expect.errorMode = 'bubble';
 
         const subjectElements = [];
@@ -243,16 +247,27 @@ module.exports = {
           subjectElements.push(element);
         });
 
-        const expected = [];
-        subject.forEach((subjectElement) => {
-          if (typeof nextArg === 'string') {
-            expected.push(expect.it((s) => expect.shift(s, 0)));
-          } else if (typeof nextArg === 'function') {
-            expected.push(nextArg);
-          } else {
-            expected.push(nextArg);
-          }
-        });
+        const valueType = expect.argTypes[0];
+
+        let expected;
+        if (!valueType) {
+          expected = [];
+          subject.forEach((subjectElement) => {
+            if (typeof nextArg === 'string') {
+              expected.push(expect.it((s) => expect.shift(s, 0)));
+            } else {
+              expected.push(nextArg);
+            }
+          });
+        } else if (valueType.is('array-like')) {
+          expected = nextArg;
+        } else if (valueType.is('Set')) {
+          expected = [];
+          nextArg.forEach((arg) => {
+            expected.push(arg);
+          });
+        }
+
         return expect.withError(
           () => expect(subjectElements, 'to [exhaustively] satisfy', expected),
           (err) => {
@@ -273,13 +288,6 @@ module.exports = {
             });
           }
         );
-      }
-    );
-
-    expect.addAssertion(
-      '<Set> to have elements satisfying <array-like>',
-      (expect, subject, value) => {
-        return expect(subject, 'to satisfy', new Set(value));
       }
     );
 

--- a/lib/unexpected-set.js
+++ b/lib/unexpected-set.js
@@ -247,26 +247,14 @@ module.exports = {
           subjectElements.push(element);
         });
 
-        const valueType = expect.argTypes[0];
-
-        let expected;
-        if (!valueType) {
-          expected = [];
-          subject.forEach((subjectElement) => {
-            if (typeof nextArg === 'string') {
-              expected.push(expect.it((s) => expect.shift(s, 0)));
-            } else {
-              expected.push(nextArg);
-            }
-          });
-        } else if (valueType.is('array-like')) {
-          expected = nextArg;
-        } else if (valueType.is('Set')) {
-          expected = [];
-          nextArg.forEach((arg) => {
-            expected.push(arg);
-          });
-        }
+        const expected = [];
+        subjectElements.forEach((subjectElement) => {
+          if (typeof nextArg === 'string') {
+            expected.push(expect.it((s) => expect.shift(s, 0)));
+          } else {
+            expected.push(nextArg);
+          }
+        });
 
         return expect.withError(
           () => expect(subjectElements, 'to [exhaustively] satisfy', expected),

--- a/lib/unexpected-set.js
+++ b/lib/unexpected-set.js
@@ -277,23 +277,24 @@ module.exports = {
     );
 
     expect.addAssertion(
-      '<Set> to [exhaustively] satisfy <Set>',
+      '<Set> to have elements satisfying <array-like>',
       (expect, subject, value) => {
-        const valueElements = [];
-        value.forEach((element) => {
-          valueElements.push(element);
-        });
-        return expect(subject, 'to [exhaustively] satisfy', valueElements);
+        return expect(subject, 'to satisfy', new Set(value));
       }
     );
 
     expect.addAssertion(
-      '<Set> to [exhaustively] satisfy <array-like>',
-      (expect, subject, valueElements) => {
+      '<Set> to [exhaustively] satisfy <Set>',
+      (expect, subject, value) => {
         const subjectElements = [];
         subject.forEach((element) => {
           subjectElements.push(element);
         });
+        const valueElements = [];
+        value.forEach((element) => {
+          valueElements.push(element);
+        });
+
         const promiseBySubjectIndexAndValueIndex = subjectElements.map(
           () => new Array(valueElements.length)
         );
@@ -327,12 +328,11 @@ module.exports = {
               !promiseByValueIndexAndSubjectIndex.every((row) =>
                 row.some((promise) => promise.isFulfilled())
               ) ||
-              (expect.flags.exhaustively &&
-                !subjectElements.every((subjectElement, i) =>
-                  promiseByValueIndexAndSubjectIndex.some((row) =>
-                    row[i].isFulfilled()
-                  )
-                ))
+              !subjectElements.every((subjectElement, i) =>
+                promiseByValueIndexAndSubjectIndex.some((row) =>
+                  row[i].isFulfilled()
+                )
+              )
             ) {
               expect.fail({
                 diff(output, diff, inspect, equal) {
@@ -367,7 +367,6 @@ module.exports = {
                           subjectElements.length
                         );
                         if (
-                          expect.flags.exhaustively &&
                           !promiseBySubjectIndexAndValueIndex[
                             subjectIndex
                           ].some((promise, valueIndex) =>

--- a/test/unexpected-set.js
+++ b/test/unexpected-set.js
@@ -140,24 +140,24 @@ describe('unexpected-set', () => {
 
   describe('to have items satisfying assertion', () => {
     it('should succeed', () => {
-      expect(new Set([1, 2, 3]), 'to have items satisfying to be a number');
+      expect(new Set([1, 2, 3]), 'to have items satisfying', [1, 2, 3]);
     });
 
     it('should fail with a diff', () => {
       expect(
         () => {
-          expect(
-            new Set([1, 2, 'foo']),
-            'to have items satisfying to be a number'
-          );
+          expect(new Set([1, 2, 'foo']), 'to have items satisfying', [
+            1,
+            'foo',
+          ]);
         },
         'to throw',
-        "expected Set([ 1, 2, 'foo' ]) to have items satisfying to be a number\n" +
+        "expected Set([ 1, 2, 'foo' ]) to have items satisfying [ 1, 'foo' ]\n" +
           '\n' +
           'Set([\n' +
           '  1,\n' +
-          '  2,\n' +
-          "  'foo' // should be a number\n" +
+          '  2, // should be removed\n' +
+          "  'foo'\n" +
           '])'
       );
     });
@@ -167,30 +167,44 @@ describe('unexpected-set', () => {
         expect(new Set([]), 'to have items satisfying to be a number');
       }, 'to throw');
     });
-  });
 
-  describe('to have elements satisfying assertion', () => {
-    it('should succeed', () => {
-      expect(new Set([1, 2, 3]), 'to have elements satisfying', [1, 2, 3]);
+    describe('with a Set on the RHS', () => {
+      it('should succeed against Set', () => {
+        expect(
+          new Set([1, 2, 3]),
+          'to have items satisfying',
+          new Set([1, 2, 3])
+        );
+      });
     });
 
-    it('should fail with a diff', () => {
-      expect(
-        () => {
-          expect(new Set([1, 2, 'foo']), 'to have elements satisfying', [
-            1,
-            'foo',
-          ]);
-        },
-        'to throw',
-        "expected Set([ 1, 2, 'foo' ]) to have elements satisfying [ 1, 'foo' ]\n" +
-          '\n' +
-          'Set([\n' +
-          '  1,\n' +
-          '  2, // should be removed\n' +
-          "  'foo'\n" +
-          '])'
-      );
+    describe('with a chained assertion on the RHS', () => {
+      it('should succeed', () => {
+        expect(
+          new Set([1, 2, 3]),
+          'to have items satisfying',
+          'to be a number'
+        );
+      });
+
+      it('should fail with a diff', () => {
+        expect(
+          () => {
+            expect(
+              new Set([1, 2, 'foo']),
+              'to have items satisfying to be a number'
+            );
+          },
+          'to throw',
+          "expected Set([ 1, 2, 'foo' ]) to have items satisfying to be a number\n" +
+            '\n' +
+            'Set([\n' +
+            '  1,\n' +
+            '  2,\n' +
+            "  'foo' // should be a number\n" +
+            '])'
+        );
+      });
     });
   });
 

--- a/test/unexpected-set.js
+++ b/test/unexpected-set.js
@@ -176,7 +176,7 @@ describe('unexpected-set', () => {
       }, 'to throw');
     });
 
-    describe('with a chained assertion on the RHS', () => {
+    describe('with a compound assertion on the RHS', () => {
       it('should succeed', () => {
         expect(
           new Set([1, 2, 3]),

--- a/test/unexpected-set.js
+++ b/test/unexpected-set.js
@@ -140,24 +140,32 @@ describe('unexpected-set', () => {
 
   describe('to have items satisfying assertion', () => {
     it('should succeed', () => {
-      expect(new Set([1, 2, 3]), 'to have items satisfying', [1, 2, 3]);
+      expect(new Set([[1], [2], [3]]), 'to have items satisfying', [
+        expect.it('to be a number').and('to be greater than', 0),
+      ]);
     });
 
     it('should fail with a diff', () => {
       expect(
         () => {
-          expect(new Set([1, 2, 'foo']), 'to have items satisfying', [
-            1,
-            'foo',
+          expect(new Set([[1], [2], ['foo']]), 'to have items satisfying', [
+            expect.it('to be a number').and('to be greater than', 0),
           ]);
         },
         'to throw',
-        "expected Set([ 1, 2, 'foo' ]) to have items satisfying [ 1, 'foo' ]\n" +
+        "expected Set([ [ 1 ], [ 2 ], [ 'foo' ] ]) to have items satisfying\n" +
+          '[\n' +
+          "  expect.it('to be a number')\n" +
+          "          .and('to be greater than', 0)\n" +
+          ']\n' +
           '\n' +
           'Set([\n' +
-          '  1,\n' +
-          '  2, // should be removed\n' +
-          "  'foo'\n" +
+          '  [ 1 ],\n' +
+          '  [ 2 ],\n' +
+          '  [\n' +
+          "    'foo' // ⨯ should be a number and\n" +
+          '          // ⨯ should be greater than 0\n' +
+          '  ]\n' +
           '])'
       );
     });
@@ -166,16 +174,6 @@ describe('unexpected-set', () => {
       expect(() => {
         expect(new Set([]), 'to have items satisfying to be a number');
       }, 'to throw');
-    });
-
-    describe('with a Set on the RHS', () => {
-      it('should succeed against Set', () => {
-        expect(
-          new Set([1, 2, 3]),
-          'to have items satisfying',
-          new Set([1, 2, 3])
-        );
-      });
     });
 
     describe('with a chained assertion on the RHS', () => {


### PR DESCRIPTION
The behaviour of allowing a set to compare against an array as part
of "to satisfy" has shown itself to be surprising - exclude this
behaviour from "to satisfy" and rename it as a separate assertion
which still allows an array-like on the RHS.

Perhaps more importantly a non-exhaustive satisfy passed with a
subset on the RHS. This is another very surprising behaviour given
arrays in core enforce an equal length. Switch to enforcing the Set
being equal size by default.